### PR TITLE
Fix content typos in HTML (Updated)

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -191,7 +191,7 @@
       <p class='leading'>A crypto scam is a malicious attempt to steal your crypto assets, consisting of two distinct parts: <strong>deceit</strong>—how a scammer tricks you, and <strong>payload</strong>—what the scammer does with your account.</p>
       <ul class='cards no-scrollbar'>
         <li class='card'>
-          <div class='led led-warning'>Deceipt</div>
+          <div class='led led-warning'>Deceit</div>
           <strong>Malware</strong>
           <p>A malware is malicious software either masquerading as legitimate software, or added on to legitimate software if you download it from an unreliable source.</p>
           <button type='button' aria-haspopup='dialog' aria-controls='scam-malware'>
@@ -202,7 +202,7 @@
           </button>
         </li>
         <li class='card'>
-          <div class='led led-warning'>Deceipt</div>
+          <div class='led led-warning'>Deceit</div>
           <strong>Imposter dApp</strong>
           <p>A fake website or app that mimics a real one to steal assets or data. It tricks users into connecting wallets or approving malicious transactions.</p>
           <button type='button' aria-haspopup='dialog' aria-controls='scam-imposter'>
@@ -213,7 +213,7 @@
           </button>
         </li>
         <li class='card'>
-          <div class='led led-warning'>Deceipt</div>
+          <div class='led led-warning'>Deceit</div>
           <strong>Broken Promise dApp</strong>
           <p>A dApp that promises something to the user, but fails to deliver on that promise. These are often promoted in chat rooms, via direct message, or via fake 'support'.</p>
           <button type='button' aria-haspopup='dialog' aria-controls='scam-broken-promise'>
@@ -224,7 +224,7 @@
           </button>
         </li>
         <li class='card'>
-          <div class='led led-warning'>Deceipt</div>
+          <div class='led led-warning'>Deceit</div>
           <strong>Fake Support</strong>
           <p>Scammers offering “help” but trick victims into revealing private keys, seed phrases, or clicking malicious links.</p>
           <button type='button' aria-haspopup='dialog' aria-controls='scam-fake-support'>
@@ -312,7 +312,7 @@
           </p>
         </article>
         <article>
-          <h4>Interaction With Source Univerified Contract</h4>
+          <h4>Interaction With Source Unverified Contract</h4>
           <p>Token approvals to contracts not source verified on Etherscan</p>
         </article>
         <article>


### PR DESCRIPTION
## Summary
- "Deceipt" → "Deceit" (4 occurrences in Scams section)
- "Univerified" → "Unverified" (Protections section)

## Test plan
- [x] Verified in browser