### PR TITLE
Add privacy policy fallback link

### DIFF
--- a/dist/index.css
+++ b/dist/index.css
@@ -334,19 +334,37 @@
   }
 
   .parallax {
-    height: 100dvh;
-    overflow: hidden;
+    min-height: 100dvh;
+  }
+
+  html.parallax {
+    scroll-behavior: smooth;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    scrollbar-gutter: stable;
+    scrollbar-width: auto;
+    scrollbar-color: var(--accent) var(--background);
+  }
+
+  html.parallax::-webkit-scrollbar {
+    width: 12px;
+  }
+
+  html.parallax::-webkit-scrollbar-track {
+    background: var(--background);
+  }
+
+  html.parallax::-webkit-scrollbar-thumb {
+    background: var(--accent);
+    border: 3px solid var(--background);
+    border-radius: 999px;
   }
 
   .parallax-container {
-    scroll-behavior: smooth;
-    perspective: 10px;
-    width: 100vw;
-    height: 100dvh;
-    transform-style: preserve-3d;
+    width: 100%;
+    min-height: 100dvh;
     margin: 0;
     display: grid;
-    overflow: hidden scroll;
   }
 
   .parallax-container > * {
@@ -357,7 +375,6 @@
   .parallax-bg {
     width: 100%;
     height: 100%;
-    transform-style: preserve-3d;
     grid-template-areas: "hero";
     display: grid;
     position: absolute;
@@ -368,8 +385,9 @@
     background-image: url("images/bg-hero.webp");
     background-size: cover;
     grid-area: hero;
-    height: 200vh;
-    transform: translateZ(-10px)scale(2);
+    width: 100%;
+    height: 100%;
+    transform: none;
   }
 
   @media (min-width: 640px) {
@@ -460,32 +478,7 @@
   }
 
   dialog::backdrop {
-    -webkit-backdrop-filter: blur(5px);
-    backdrop-filter: blur(5px);
-  }
-
-  dialog button[formmethod="dialog"] {
-    cursor: pointer;
-    width: 2rem;
-    height: 2rem;
-    color: var(--accent);
-    border-radius: 4px;
-    place-content: center;
-    column-gap: .5em;
-    margin-left: auto;
-    font-size: 1.5rem;
-    display: grid;
-    position: sticky;
-    top: 0;
-  }
-
-  dialog button[formmethod="dialog"]:before {
-    content: "✕";
-  }
-
-  dialog button[formmethod="dialog"]:focus, dialog button[formmethod="dialog"]:hover {
-    text-shadow: 0 0 20px 5px var(--accent);
-    outline: none;
+    background: oklch(from var(--primary) l c h / .5);
   }
 
   nav:has(ul[role="menubar"]) {
@@ -495,8 +488,6 @@
 
   nav:has(ul[role="menubar"]):focus, nav:has(ul[role="menubar"]):focus-within {
     background: oklch(from var(--primary) l c h / .9);
-    -webkit-backdrop-filter: blur(5px);
-    backdrop-filter: blur(5px);
     place-content: center;
     row-gap: 1rem;
     width: 100vw;
@@ -513,8 +504,6 @@
   @media (min-width: 1024px) {
     :is(nav:has(ul[role="menubar"]):focus, nav:has(ul[role="menubar"]):focus-within) {
       background: initial;
-      -webkit-backdrop-filter: none;
-      backdrop-filter: none;
       justify-content: space-between;
       row-gap: 0;
       width: auto;
@@ -881,7 +870,7 @@
   top: 0;
 }
 
-.topbar:is(.scrolled .topbar), .topbar:has(nav:focus) {
+.scrolled .topbar, .topbar:has(nav:focus) {
   background-color: oklch(from var(--primary) l c h / .75);
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
@@ -1621,20 +1610,36 @@ body > footer .container {
   text-align: center;
 }
 
-body > footer button {
-  color: var(--accent);
-  text-underline-offset: .2em;
-  text-decoration: underline;
-  cursor: pointer;
-}
+  body > footer button, body > footer a {
+    color: var(--accent);
+    text-underline-offset: .2em;
+    text-decoration: underline;
+    cursor: pointer;
+  }
 
-body > footer button:hover {
-  color: var(--accent);
-}
+  body > footer button:hover, body > footer a:hover {
+    color: var(--accent);
+  }
 
-.privacy-policy-statement {
-  color: var(--muted-foreground);
-}
+  .privacy-policy-statement {
+    color: var(--muted-foreground);
+  }
+
+  #privacy-policy {
+    display: none;
+    background-image: linear-gradient(to bottom, oklch(from var(--primary) calc(l - .06) c h), oklch(from var(--primary) calc(l - .06) c h) 75%, var(--background));
+    color: var(--muted-foreground);
+    padding-block: 4rem;
+    scroll-margin-top: var(--header-height);
+  }
+
+  #privacy-policy:target {
+    display: block;
+  }
+
+  #privacy-policy .container {
+    padding-inline: 2rem;
+  }
 
 .privacy-policy-statement h2 {
   color: var(--foreground);
@@ -1648,6 +1653,6 @@ body > footer button:hover {
   font-size: 1.5rem;
 }
 
-.privacy-policy-statement p {
-  margin-bottom: 1rem;
-}
+  .privacy-policy-statement p {
+    margin-bottom: 1rem;
+  }

--- a/dist/index.html
+++ b/dist/index.html
@@ -451,13 +451,12 @@
     <div class='container'>
       <p>&copy; 2025 Dark Florist</p>
       <nav>
-        <button type='button' aria-haspopup='dialog' aria-controls='privacy-policy-modal'>Privacy Policy</button>
+        <a class='footer-link' href='#privacy-policy'>Privacy Policy</a>
       </nav>
     </div>
   </footer>
-  <dialog id='privacy-policy-modal'>
-    <form method='dialog'>
-      <button formmethod='dialog'></button>
+  <section id='privacy-policy'>
+    <div class='container'>
       <article class='privacy-policy-statement'>
         <h2>Privacy Policy</h2>
         <p>Our Privacy Policy was last updated on April 18, 2023. This Privacy Policy describes Dark Florist's policies and procedures on the collection, use and disclosure of your information when you use our service and tells you about your privacy rights and how the law protects you.</p>
@@ -467,13 +466,13 @@
         <p>We do not knowingly collect information online from children under 13 (nor anyone over 13). If you learn that you or your children have provided Dark Florist with Personal Information, please contact us. If we become aware that Personal Information has been collected we will take steps to remove that information from our servers.</p>
 
         <h3>Contact Us</h3>
-        <p>We are committed to processing your personal data lawfully and to respecting your data protection rights. Please contact us if you have any questions about this notice or the personal data we hold about you. Our contact details are: admin@dark.florist, marking your communication 'Data Protection Enquiry'.</p>
+        <p>We are committed to processing your personal data lawfully and to respecting your data protection rights. Please contact us if you have any questions about this notice. Our contact details are: admin@dark.florist.</p>
 
         <h3>Changes To This Policy</h3>
         <p>The Company may revise this Privacy Policy from time to time. If we make a change to this policy that, in our sole discretion, is material, we will take steps to notify all users by a notice on the site. By continuing to access or use the Services after those changes become effective, you agree to be bound by the revised Privacy Policy.</p>
       </article>
-    </form>
-  </dialog>
+    </div>
+  </section>
   <dialog id='scam-malware'>
     <form method='dialog'>
       <button formmethod='dialog'></button>

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,6 @@
 const initFixedHeader = () => {
-  const container = document.body;
-  const isPageScrolled = () => document.body.scrollTop > 0;
+  const container = document.scrollingElement || document.documentElement;
+  const isPageScrolled = () => container.scrollTop > 0;
   container.addEventListener("scroll", () => {
     if (isPageScrolled()) {
       container.classList.add("scrolled");
@@ -25,6 +25,11 @@ const initModalBindings = () => {
       dialog.open = true;
       return;
     }
+    if ("hidden" in dialog) {
+      dialog.hidden = false;
+      dialog.querySelector("[formmethod=dialog]")?.focus();
+      return;
+    }
     console.error("Element is not a dialog element");
   };
   const closeDialog = (dialog) => {
@@ -39,6 +44,10 @@ const initModalBindings = () => {
     }
     if ("open" in dialog) {
       dialog.open = false;
+      return;
+    }
+    if ("hidden" in dialog) {
+      dialog.hidden = true;
       return;
     }
     console.error("Element is not a dialog element");


### PR DESCRIPTION
Add a non-modal fallback target for the privacy policy so Chrome users still see the content even if the dialog path fails. The footer trigger remains modal-enhanced when JS works, but now degrades to an in-page section instead of doing nothing.